### PR TITLE
Add libssl-dev dependency on Debian

### DIFF
--- a/manifests/back/dependencies.pp
+++ b/manifests/back/dependencies.pp
@@ -1,10 +1,40 @@
 class taiga::back::dependencies {
   case $::osfamily {
     'Debian': {
-      $depends = ['build-essential', 'binutils-doc', 'autoconf', 'flex', 'bison', 'libjpeg-dev', 'libfreetype6-dev', 'libzmq3-dev', 'libgdbm-dev', 'libncurses5-dev', 'automake', 'libtool', 'libffi-dev', 'curl', 'gettext', 'python3', 'python3-pip', 'python-dev', 'python3-dev', 'python-pip', 'virtualenvwrapper', 'libxml2-dev', 'libxslt1-dev', 'libpq-dev']
+      $depends = [
+        'build-essential',
+        'binutils-doc',
+        'autoconf',
+        'flex',
+        'bison',
+        'libjpeg-dev',
+        'libfreetype6-dev',
+        'libzmq3-dev',
+        'libgdbm-dev',
+        'libncurses5-dev',
+        'automake',
+        'libtool',
+        'libffi-dev',
+        'curl',
+        'gettext',
+        'python3',
+        'python3-pip',
+        'python-dev',
+        'python3-dev',
+        'python-pip',
+        'virtualenvwrapper',
+        'libxml2-dev',
+        'libxslt1-dev',
+        'libpq-dev'
+      ]
     }
     'FreeBSD': {
-      $depends = ['python3', 'py27-virtualenvwrapper', 'libxml2', 'libxslt']
+      $depends = [
+        'python3',
+        'py27-virtualenvwrapper',
+        'libxml2',
+        'libxslt'
+      ]
     }
     default: {
       fail("Unsupported operating system: ${::osfamily}")

--- a/manifests/back/dependencies.pp
+++ b/manifests/back/dependencies.pp
@@ -25,7 +25,7 @@ class taiga::back::dependencies {
         'virtualenvwrapper',
         'libxml2-dev',
         'libxslt1-dev',
-        'libpq-dev'
+        'libpq-dev',
       ]
     }
     'FreeBSD': {
@@ -33,7 +33,7 @@ class taiga::back::dependencies {
         'python3',
         'py27-virtualenvwrapper',
         'libxml2',
-        'libxslt'
+        'libxslt',
       ]
     }
     default: {

--- a/manifests/back/dependencies.pp
+++ b/manifests/back/dependencies.pp
@@ -16,6 +16,7 @@ class taiga::back::dependencies {
         'libjpeg-dev',
         'libncurses5-dev',
         'libpq-dev',
+        'libssl-dev',
         'libtool',
         'libxml2-dev',
         'libxslt1-dev',

--- a/manifests/back/dependencies.pp
+++ b/manifests/back/dependencies.pp
@@ -2,38 +2,38 @@ class taiga::back::dependencies {
   case $::osfamily {
     'Debian': {
       $depends = [
-        'build-essential',
-        'binutils-doc',
         'autoconf',
-        'flex',
-        'bison',
-        'libjpeg-dev',
-        'libfreetype6-dev',
-        'libzmq3-dev',
-        'libgdbm-dev',
-        'libncurses5-dev',
         'automake',
-        'libtool',
-        'libffi-dev',
+        'binutils-doc',
+        'bison',
+        'build-essential',
         'curl',
+        'flex',
         'gettext',
-        'python3',
-        'python3-pip',
-        'python-dev',
-        'python3-dev',
-        'python-pip',
-        'virtualenvwrapper',
+        'libffi-dev',
+        'libfreetype6-dev',
+        'libgdbm-dev',
+        'libjpeg-dev',
+        'libncurses5-dev',
+        'libpq-dev',
+        'libtool',
         'libxml2-dev',
         'libxslt1-dev',
-        'libpq-dev',
+        'libzmq3-dev',
+        'python-dev',
+        'python-pip',
+        'python3',
+        'python3-dev',
+        'python3-pip',
+        'virtualenvwrapper',
       ]
     }
     'FreeBSD': {
       $depends = [
-        'python3',
-        'py27-virtualenvwrapper',
         'libxml2',
         'libxslt',
+        'py27-virtualenvwrapper',
+        'python3',
       ]
     }
     default: {


### PR DESCRIPTION
The *cryptography* dependency requires some headers provided by this package.