### PR TITLE
Ensure pip and setuptools are up-to-date

### DIFF
--- a/manifests/back/install.pp
+++ b/manifests/back/install.pp
@@ -1,10 +1,28 @@
 class taiga::back::install {
   include ::taiga::back
 
+  exec { 'taiga-back-upgrade-pip':
+    command     => "${taiga::back::install_dir}/bin/pip install --upgrade pip",
+    cwd         => $taiga::back::install_dir,
+    refreshonly => true,
+    user        => $taiga::back::user,
+  }
+
+  exec { 'taiga-back-upgrade-setuptools':
+    command     => "${taiga::back::install_dir}/bin/pip install --upgrade setuptools",
+    cwd         => $taiga::back::install_dir,
+    refreshonly => true,
+    user        => $taiga::back::user,
+  }
+
   exec { 'taiga-back-pip-install':
     command     => "${taiga::back::install_dir}/bin/pip install --requirement requirements.txt --upgrade",
     cwd         => $taiga::back::install_dir,
     refreshonly => true,
     user        => $taiga::back::user,
   }
+
+  Exec['taiga-back-upgrade-pip'] ->
+  Exec['taiga-back-upgrade-setuptools'] ->
+  Exec['taiga-back-pip-install']
 }


### PR DESCRIPTION
Installation may fail when dependencies use new features of these
packages and they are not up-to-date.