### PR TITLE
Disable timeout for pip install

### DIFF
--- a/manifests/back/install.pp
+++ b/manifests/back/install.pp
@@ -20,6 +20,7 @@ class taiga::back::install {
     cwd         => $taiga::back::install_dir,
     refreshonly => true,
     user        => $taiga::back::user,
+    timeout     => 0,
   }
 
   Exec['taiga-back-upgrade-pip'] ->


### PR DESCRIPTION
Installing taiga dependencies can take a **long** time, so disable
timeout to avoid interrupting the process.