### PR TITLE
Move Python parameters to param class

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,18 @@ Default: 'taiga'
 
 Default: 'undef'
 
+##### `python_path`
+
+Default: operating-system dependant
+
+##### `python_version`
+
+Default: operating-system dependant
+
+##### `virtualenv`
+
+Default: operating-system dependant
+
 #### Class: `taiga::front`
 
 Installs and configure [taiga-front-dist](https://github.com/taigaio/taiga-front-dist).

--- a/manifests/back.pp
+++ b/manifests/back.pp
@@ -27,7 +27,10 @@ class taiga::back (
   $email_port = 25,
   $email_user = undef,
   $email_password = undef,
-) {
+  $python_path = $taiga::back::params::python_path,
+  $python_version = $taiga::back::params::python_version,
+  $virtualenv = $taiga::back::params::virtualenv,
+) inherits taiga::back::params {
   include ::taiga::back::user
   include ::taiga::back::dependencies
   include ::taiga::back::repo

--- a/manifests/back/env.pp
+++ b/manifests/back/env.pp
@@ -1,19 +1,9 @@
 class taiga::back::env {
   include ::taiga::back
 
-  $virtualenv = $::osfamily ? {
-    'Debian'  => '/usr/bin/virtualenv',
-    'FreeBSD' => '/usr/local/bin/virtualenv',
-  }
-
-  $python3 = $::osfamily ? {
-    'Debian'  => '/usr/bin/python3.4',
-    'FreeBSD' => '/usr/local/bin/python3.4',
-  }
-
   exec { 'taiga-back-virtualenv':
-    command => "${virtualenv} -p ${python3} ${taiga::back::install_dir}",
-    creates => "${taiga::back::install_dir}/lib/python3.4/site-packages/django",
+    command => "${taiga::back::virtualenv} -p ${taiga::back::python_path}${taiga::back::python_version} ${taiga::back::install_dir}",
+    creates => "${taiga::back::install_dir}/lib/python${taiga::back::python_version}/site-packages/django",
     user    => $taiga::back::user,
   }
 }

--- a/manifests/back/ldap.pp
+++ b/manifests/back/ldap.pp
@@ -4,6 +4,6 @@ class taiga::back::ldap {
   exec { 'taiga_contrib_ldap_auth-deploy':
     command => "${taiga::back::install_dir}/bin/pip install git+https://github.com/ensky/taiga-contrib-ldap-auth.git",
     user    => $taiga::back::user,
-    creates => "${taiga::back::install_dir}/lib/python3.4/site-packages/taiga_contrib_ldap_auth",
+    creates => "${taiga::back::install_dir}/lib/python${taiga::back::python_version}/site-packages/taiga_contrib_ldap_auth",
   }
 }

--- a/manifests/back/params.pp
+++ b/manifests/back/params.pp
@@ -1,0 +1,27 @@
+class taiga::back::params {
+  case $::osfamily {
+    'debian': {
+      $python_path = '/usr/bin/python'
+      case $::lsbdistcodename {
+        'jessie': {
+          $python_version = '3.4'
+        }
+        'stretch': {
+          $python_version = '3.5'
+        }
+        default: {
+          fail("unsupported lsbdistcodename ${::lsbdistcodename}")
+        }
+      }
+      $virtualenv = '/usr/bin/virtualenv'
+    }
+    'freebsd': {
+      $python_path = '/usr/local/bin/python'
+      $python_version = '3.4'
+      $virtualenv = '/usr/local/bin/virtualenv'
+    }
+    default: {
+      fail("unsupported osfamily ${::osfamily}")
+    }
+  }
+}


### PR DESCRIPTION
This allows a slightly easier configuration of different Python versions
(e.g. jessie vs. stretch) and allows personalization if desired (e.g.
using the current default Python 3.5 on FreeBSD while this module use 3.).