### PR TITLE
Give access to the global site-packages modules to virtualenv

### DIFF
--- a/manifests/back/env.pp
+++ b/manifests/back/env.pp
@@ -2,7 +2,7 @@ class taiga::back::env {
   include ::taiga::back
 
   exec { 'taiga-back-virtualenv':
-    command => "${taiga::back::virtualenv} -p ${taiga::back::python_path}${taiga::back::python_version} ${taiga::back::install_dir}",
+    command => "${taiga::back::virtualenv} --system-site-packages -p ${taiga::back::python_path}${taiga::back::python_version} ${taiga::back::install_dir}",
     creates => "${taiga::back::install_dir}/lib/python${taiga::back::python_version}/site-packages/django",
     user    => $taiga::back::user,
   }


### PR DESCRIPTION
This commit allow to use system-wide already available python packages from taiga-back virtual environment.

This fixes from-scratch install on Debian 9: without this, pip3 try to install 'cryptography' 1.7.1 python module, but this module does have troubles with current libssl headers.

https://github.com/pyca/cryptography/issues/3605