### PR TITLE
Depend on the Python 3 flavored version of virtualenvwrapper

### DIFF
--- a/manifests/back/dependencies.pp
+++ b/manifests/back/dependencies.pp
@@ -33,7 +33,7 @@ class taiga::back::dependencies {
       $depends = [
         'libxml2',
         'libxslt',
-        'py27-virtualenvwrapper',
+        'py37-virtualenvwrapper',
         'python3',
       ]
     }


### PR DESCRIPTION
Python 2.7 is reaching EOL, we use Python 3 for running, and we can use Python 3 to setup the environment.

A further improvement would probably to rely on https://github.com/voxpupuli/puppet-python for abstraction.