### PR TITLE
Restore FallbackResource

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -43,15 +43,15 @@ class taiga::vhost (
   include ::apache::mod::passenger
 
   apache::vhost { $hostname:
-    port                   => $port,
-    docroot                => "${front_directory}/dist",
-    manage_docroot         => false,
-    ssl                    => $ssl,
-    ssl_cert               => $ssl_cert,
-    ssl_key                => $ssl_key,
-    ssl_chain              => $ssl_chain,
+    port                       => $port,
+    docroot                    => "${front_directory}/dist",
+    manage_docroot             => false,
+    ssl                        => $ssl,
+    ssl_cert                   => $ssl_cert,
+    ssl_key                    => $ssl_key,
+    ssl_chain                  => $ssl_chain,
 
-    aliases                => [
+    aliases                    => [
       {
         alias => '/media',
         path  => "${back_directory}/media",
@@ -62,22 +62,32 @@ class taiga::vhost (
       },
     ],
 
-    passenger_app_root     => $back_directory,
-    passenger_app_type     => 'wsgi',
-    passenger_startup_file => 'passenger_wsgi.py',
-    passenger_python       => "${back_directory}/bin/python",
-    passenger_user         => $back_user,
+    fallbackresource           => '/index.html',
 
-    directories            => [
+    passenger_high_performance => false,
+
+    directories                => [
       {
         path           => "${front_directory}/dist",
         options        => 'None',
         allow_override => 'None',
       },
       {
-        passenger_base_uri     => '/admin',
+        path                   => '/api',
         provider               => 'location',
+        fallbackresource       => 'disabled',
+        passenger_base_uri     => '/',
+        passenger_app_root     => $back_directory,
+        passenger_app_type     => 'wsgi',
+        passenger_startup_file => 'passenger_wsgi.py',
+        passenger_python       => "${back_directory}/bin/python",
+        passenger_user         => $back_user,
+      },
+      {
         path                   => '/admin',
+        provider               => 'location',
+        fallbackresource       => 'disabled',
+        passenger_base_uri     => '/admin',
         passenger_app_root     => $back_directory,
         passenger_app_type     => 'wsgi',
         passenger_startup_file => 'passenger_wsgi.py',


### PR DESCRIPTION
It is used to load an URL when not clicking links from the home page
(e.g. when loading a page from a link or bookmarks).  The rest of
navigation was unaffected because the front UI change the address in the
address bar on each clic.

For it to work, PassengerHighPerformance must be turned off.

The current version of the apache module does not handle this properly
ATM, but this only affects users enabling PassengerHighPerformance.