### PR TITLE
Allow disabling inclusion of owner's username in projects slug

### DIFF
--- a/manifests/back.pp
+++ b/manifests/back.pp
@@ -33,6 +33,7 @@
 # @param python_version Version of Python.
 # @param virtualenv Path to virtualenv.
 # @param change_notification_min_interval Interval for sending change notifications.
+# @param default_project_slug_prefix Add username to project slug
 class taiga::back (
   String[1]                  $front_hostname,
   Enum['http', 'https']      $front_protocol,
@@ -67,6 +68,7 @@ class taiga::back (
   String[1]                  $python_version = $taiga::back::params::python_version,
   Stdlib::Absolutepath       $virtualenv = $taiga::back::params::virtualenv,
   Optional[Integer]          $change_notification_min_interval = undef,
+  Optional[Boolean]          $default_project_slug_prefix = undef,
 ) {
   contain taiga::back::user
   contain taiga::back::dependencies

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,7 @@
 # @param ssl_key Key to use for apache VirtualHost.
 # @param ssl_chain Certificate chain to use for apache VirtualHost.
 # @param change_notification_min_interval Interval for sending change notifications.
+# @param default_project_slug_prefix Add username to project slug
 class taiga (
   String[1]                      $hostname,
   String[1]                      $back_secret_key,
@@ -51,6 +52,7 @@ class taiga (
   Optional[Stdlib::Absolutepath] $ssl_key = undef,
   Optional[Stdlib::Absolutepath] $ssl_chain = undef,
   Optional[Integer]              $change_notification_min_interval = undef,
+  Optional[Boolean]              $default_project_slug_prefix = undef,
 ) {
   $ldap_enable = $ldap_server ? {
     undef   => false,
@@ -91,6 +93,7 @@ class taiga (
     ldap_email_property              => $ldap_email_property,
     ldap_full_name_property          => $ldap_full_name_property,
     change_notification_min_interval => $change_notification_min_interval,
+    default_project_slug_prefix      => $default_project_slug_prefix,
   }
 
   class { 'taiga::vhost':

--- a/templates/back/local.py.epp
+++ b/templates/back/local.py.epp
@@ -43,3 +43,6 @@ CHANGE_NOTIFICATIONS_MIN_INTERVAL = <%= $taiga::back::change_notification_min_in
 # for enable github login/singin.
 #GITHUB_API_CLIENT_ID = "yourgithubclientid"
 #GITHUB_API_CLIENT_SECRET = "yourgithubclientsecret"
+<% if $taiga::back::default_project_slug_prefix != undef { -%>
+DEFAULT_PROJECT_SLUG_PREFIX = <%= String($taiga::back::default_project_slug_prefix, '%T') %>
+<% } -%>


### PR DESCRIPTION
Add a `default_project_slug_prefix` parameter to set [DEFAULT_PROJECT_SLUG_PREFIX](REF).

This setting can be used to prevent the username to be prepended to the project's slug.

[REF]: https://github.com/taigaio/taiga-front/issues/652#issuecomment-778116547