### PR TITLE
Relocate Taiga repositories

### DIFF
--- a/manifests/back/repo.pp
+++ b/manifests/back/repo.pp
@@ -12,7 +12,7 @@ class taiga::back::repo {
   -> vcsrepo { $taiga::back::install_dir:
     ensure   => $taiga::back::repo_ensure,
     provider => 'git',
-    source   => 'https://github.com/taigaio/taiga-back.git',
+    source   => 'https://github.com/kaleidos-ventures/taiga-back.git',
     revision => $taiga::back::repo_revision,
     user     => $taiga::back::user,
   }

--- a/manifests/front/repo.pp
+++ b/manifests/front/repo.pp
@@ -12,7 +12,7 @@ class taiga::front::repo {
   -> vcsrepo { $taiga::front::install_dir:
     ensure   => $taiga::front::repo_ensure,
     provider => 'git',
-    source   => 'https://github.com/taigaio/taiga-front-dist.git',
+    source   => 'https://github.com/kaleidos-ventures/taiga-front-dist.git',
     revision => $taiga::front::repo_revision,
     user     => $taiga::front::user,
   }


### PR DESCRIPTION
The Taiga repositories show the following warning:

> ⚠️ Relocation warning
> =====================
>
> This repository has been relocated to [the new organization Kaleidos Ventures](https://github.com/kaleidos-ventures/taiga-front-dist/) where the team will continue developing Taiga. Please, follow us and contribute on the new location. New issues should be placed as well under the new Github organization.

Relocate the repositories accordingly.

Existing users will have to update the remote URL of their repository manualy, hence the **backwards-incompatible** label:

```sh-session
$ cd /srv/www/taiga-back
$ git remote set-url master https://github.com/kaleidos-ventures/taiga-back.git
$ cd /srv/www/taiga-front
$ git remote set-url master https://github.com/kaleidos-ventures/taiga-front-dist.git
```