### PR TITLE
Explicitely add directory entries for /media, /static

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -70,6 +70,16 @@ class taiga::vhost (
 
     directories                => [
       {
+        path           => "${back_directory}/media",
+        options        => 'None',
+        allow_override => 'None',
+      },
+      {
+        path           => "${back_directory}/static",
+        options        => 'None',
+        allow_override => 'None',
+      },
+      {
         path           => "${front_directory}/dist",
         options        => 'None',
         allow_override => 'None',


### PR DESCRIPTION
These are required when running apache with root_directory_secured set
to true.
