### PR TITLE
Allow management of Django's `ADMINS` setting

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,6 +34,10 @@
 
 * `taiga::back::manage`: Allow running actions in Taiga back environment
 
+### Data types
+
+* [`Taiga::Admin`](#Taiga--Admin): A Taiga::Admin is composed of a full name and an e-mail address
+
 ### Tasks
 
 * [`project_change_slug`](#project_change_slug): Change a project slug
@@ -63,6 +67,7 @@ The following parameters are available in the `taiga` class:
 * [`venv_directory`](#-taiga--venv_directory)
 * [`front_directory`](#-taiga--front_directory)
 * [`back_user`](#-taiga--back_user)
+* [`back_admins`](#-taiga--back_admins)
 * [`public_register_enabled`](#-taiga--public_register_enabled)
 * [`gravatar`](#-taiga--gravatar)
 * [`ldap_server`](#-taiga--ldap_server)
@@ -161,6 +166,14 @@ Data type: `String[1]`
 Name of the user running the backend daemon.
 
 Default value: `'taiga'`
+
+##### <a name="-taiga--back_admins"></a>`back_admins`
+
+Data type: `Array[Taiga::Admin]`
+
+Administrators to notify of Taiga exceptions.
+
+Default value: `[]`
 
 ##### <a name="-taiga--public_register_enabled"></a>`public_register_enabled`
 
@@ -312,6 +325,7 @@ The following parameters are available in the `taiga::back` class:
 * [`repo_revision`](#-taiga--back--repo_revision)
 * [`install_dir`](#-taiga--back--install_dir)
 * [`venv_dir`](#-taiga--back--venv_dir)
+* [`admins`](#-taiga--back--admins)
 * [`public_register_enabled`](#-taiga--back--public_register_enabled)
 * [`ldap_enable`](#-taiga--back--ldap_enable)
 * [`ldap_server`](#-taiga--back--ldap_server)
@@ -428,6 +442,14 @@ Data type: `Stdlib::Absolutepath`
 Directory where is installed Taiga pyhton dependencies.
 
 Default value: `'/srv/www/taiga-venv'`
+
+##### <a name="-taiga--back--admins"></a>`admins`
+
+Data type: `Array[Taiga::Admin]`
+
+Administrators to notify of Taiga exceptions.
+
+Default value: `[]`
 
 ##### <a name="-taiga--back--public_register_enabled"></a>`public_register_enabled`
 
@@ -754,6 +776,14 @@ Data type: `Optional[String[1]]`
 Certificate chain to use for apache VirtualHost.
 
 Default value: `undef`
+
+## Data types
+
+### <a name="Taiga--Admin"></a>`Taiga::Admin`
+
+A Taiga::Admin is composed of a full name and an e-mail address
+
+Alias of `Tuple[String[1], Pattern[/.@./]]`
 
 ## Tasks
 

--- a/manifests/back.pp
+++ b/manifests/back.pp
@@ -14,6 +14,7 @@
 # @param repo_revision Revision for Taiga's vcs repository.
 # @param install_dir Directory where is installed the backend of Taiga.
 # @param venv_dir Directory where is installed Taiga pyhton dependencies.
+# @param admins Administrators to notify of Taiga exceptions.
 # @param public_register_enabled Enable anyone to register on this instance.
 # @param ldap_enable Enable the LDAP client.
 # @param ldap_server LDAP server.
@@ -47,6 +48,7 @@ class taiga::back (
   String[1]                  $repo_revision = 'stable',
   Stdlib::Absolutepath       $install_dir = '/srv/www/taiga-back',
   Stdlib::Absolutepath       $venv_dir = '/srv/www/taiga-venv',
+  Array[Taiga::Admin]        $admins = [],
   Boolean                    $public_register_enabled = true,
   Boolean                    $ldap_enable = false,
   Optional[String[1]]        $ldap_server = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@
 # @param venv_directory Default where is installed python dependencies.
 # @param front_directory Directory where is installed the frontend of Taiga.
 # @param back_user Name of the user running the backend daemon.
+# @param back_admins Administrators to notify of Taiga exceptions.
 # @param public_register_enabled Enable anyone to register on this instance.
 # @param gravatar Use gravatar.
 # @param ldap_server LDAP server.
@@ -39,6 +40,7 @@ class taiga (
   Stdlib::Absolutepath           $venv_directory = '/srv/www/taiga-venv',
   Stdlib::Absolutepath           $front_directory = '/srv/www/taiga-front',
   String[1]                      $back_user = 'taiga',
+  Array[Taiga::Admin]            $back_admins = [],
   Boolean                        $public_register_enabled = true,
   Boolean                        $gravatar = true,
   Optional[String[1]]            $ldap_server = undef,
@@ -77,6 +79,7 @@ class taiga (
     front_protocol                   => $protocol,
     back_hostname                    => $hostname,
     back_protocol                    => $protocol,
+    admins                           => $back_admins,
     secret_key                       => $back_secret_key,
     db_password                      => $back_db_password,
     repo_ensure                      => $repo_ensure,

--- a/templates/back/local.py.epp
+++ b/templates/back/local.py.epp
@@ -1,5 +1,7 @@
 from .common import *
 
+ADMINS = <%= $taiga::back::admins.to_python %>
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',

--- a/types/admin.pp
+++ b/types/admin.pp
@@ -1,0 +1,5 @@
+# A Taiga::Admin is composed of a full name and an e-mail address
+type Taiga::Admin = Tuple[
+  String[1],
+  Pattern[/.@./],
+]


### PR DESCRIPTION
`ADMINS` is a Django setting for people who should get error notifications:

> A list of all the people who get code error notifications. When
> DEBUG=False and AdminEmailHandler is configured in LOGGING (done by
> default), Django emails these people the details of exceptions raised
> in the request/response cycle.

The default value from Taiga is the invalid address example@example.com.  Add parameters to use custom address and default to an empty list of administrators.
