### PR TITLE
Prefer namespaced stdlib functions

### DIFF
--- a/manifests/back/dependencies.pp
+++ b/manifests/back/dependencies.pp
@@ -6,5 +6,5 @@ class taiga::back::dependencies {
 
   include python
 
-  ensure_packages($taiga::back::dependencies, { ensure => installed, })
+  stdlib::ensure_packages($taiga::back::dependencies, { ensure => installed, })
 }

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.2.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",

--- a/templates/back/local.py.epp
+++ b/templates/back/local.py.epp
@@ -1,44 +1,44 @@
 from .common import *
 
-ADMINS = <%= $taiga::back::admins.to_python %>
+ADMINS = <%= $taiga::back::admins.stdlib::to_python %>
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': <%= $taiga::back::db_name.to_python %>,
-        'USER': <%= $taiga::back::db_user.to_python %>,
-        'PASSWORD': <%= $taiga::back::db_password.to_python %>,
+        'NAME': <%= $taiga::back::db_name.stdlib::to_python %>,
+        'USER': <%= $taiga::back::db_user.stdlib::to_python %>,
+        'PASSWORD': <%= $taiga::back::db_password.stdlib::to_python %>,
         'HOST': '',
         'PORT': '',
     }
 }
 
-MEDIA_URL = <%= "${taiga::back::front_protocol}://${$taiga::back::front_hostname}/media/".to_python %>
-STATIC_URL = <%= "${taiga::back::front_protocol}://${$taiga::back::front_hostname}/static/".to_python %>
-ADMIN_MEDIA_PREFIX = <%= "${taiga::back::front_protocol}://${$taiga::back::front_hostname}/static/admin/".to_python %>
-SITES["front"]["scheme"] = <%= $taiga::back::front_protocol.to_python %>
-SITES["front"]["domain"] = <%= $taiga::back::front_hostname.to_python %>
+MEDIA_URL = <%= "${taiga::back::front_protocol}://${$taiga::back::front_hostname}/media/".stdlib::to_python %>
+STATIC_URL = <%= "${taiga::back::front_protocol}://${$taiga::back::front_hostname}/static/".stdlib::to_python %>
+ADMIN_MEDIA_PREFIX = <%= "${taiga::back::front_protocol}://${$taiga::back::front_hostname}/static/admin/".stdlib::to_python %>
+SITES["front"]["scheme"] = <%= $taiga::back::front_protocol.stdlib::to_python %>
+SITES["front"]["domain"] = <%= $taiga::back::front_hostname.stdlib::to_python %>
 
-SECRET_KEY = <%= $taiga::back::secret_key.to_python %>
+SECRET_KEY = <%= $taiga::back::secret_key.stdlib::to_python %>
 
 DEBUG = False
 TEMPLATE_DEBUG = False
-PUBLIC_REGISTER_ENABLED = <%= $taiga::back::public_register_enabled.to_python %>
+PUBLIC_REGISTER_ENABLED = <%= $taiga::back::public_register_enabled.stdlib::to_python %>
 
-DEFAULT_FROM_EMAIL = <%= "no-reply@${taiga::back::front_hostname}".to_python %>
+DEFAULT_FROM_EMAIL = <%= "no-reply@${taiga::back::front_hostname}".stdlib::to_python %>
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 
 # Uncomment and populate with proper connection parameters
 # for enable email sending. EMAIL_HOST_USER should end by @domain.tld
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_USE_TLS = <%= $taiga::back::email_use_tls.to_python %>
-EMAIL_HOST = <%= $taiga::back::email_host.to_python %>
-EMAIL_HOST_USER = <%= $taiga::back::email_user.to_python %>
-EMAIL_HOST_PASSWORD = <%= $taiga::back::email_password.to_python %>
-EMAIL_PORT = <%= $taiga::back::email_port.to_python %>
+EMAIL_USE_TLS = <%= $taiga::back::email_use_tls.stdlib::to_python %>
+EMAIL_HOST = <%= $taiga::back::email_host.stdlib::to_python %>
+EMAIL_HOST_USER = <%= $taiga::back::email_user.stdlib::to_python %>
+EMAIL_HOST_PASSWORD = <%= $taiga::back::email_password.stdlib::to_python %>
+EMAIL_PORT = <%= $taiga::back::email_port.stdlib::to_python %>
 
 <% if $taiga::back::change_notification_min_interval { -%>
-CHANGE_NOTIFICATIONS_MIN_INTERVAL = <%= $taiga::back::change_notification_min_interval.to_python %>
+CHANGE_NOTIFICATIONS_MIN_INTERVAL = <%= $taiga::back::change_notification_min_interval.stdlib::to_python %>
 <% } -%>
 
 # Uncomment and populate with proper connection parameters
@@ -46,5 +46,5 @@ CHANGE_NOTIFICATIONS_MIN_INTERVAL = <%= $taiga::back::change_notification_min_in
 #GITHUB_API_CLIENT_ID = "yourgithubclientid"
 #GITHUB_API_CLIENT_SECRET = "yourgithubclientsecret"
 <% if $taiga::back::default_project_slug_prefix != undef { -%>
-DEFAULT_PROJECT_SLUG_PREFIX = <%= $taiga::back::default_project_slug_prefix.to_python %>
+DEFAULT_PROJECT_SLUG_PREFIX = <%= $taiga::back::default_project_slug_prefix.stdlib::to_python %>
 <% } -%>

--- a/templates/front/conf.json.epp
+++ b/templates/front/conf.json.epp
@@ -1,18 +1,18 @@
 {
-    "api": <%= "${taiga::front::back_protocol}://${taiga::front::back_hostname}/api/v1/".to_json %>,
+    "api": <%= "${taiga::front::back_protocol}://${taiga::front::back_hostname}/api/v1/".stdlib::to_json %>,
 <% if $taiga::front::events { -%>
-    "eventsUrl": <%= "${taiga::front::ws_protocol}://${taiga::front::back_hostname}/events".to_json %>,
+    "eventsUrl": <%= "${taiga::front::ws_protocol}://${taiga::front::back_hostname}/events".stdlib::to_json %>,
 <% } -%>
     "debug": "true",
-    "defaultLanguage": <%= $taiga::front::default_language.to_json %>,
-    "publicRegisterEnabled": <%= $taiga::front::public_register_enabled.to_json %>,
+    "defaultLanguage": <%= $taiga::front::default_language.stdlib::to_json %>,
+    "publicRegisterEnabled": <%= $taiga::front::public_register_enabled.stdlib::to_json %>,
     "feedbackEnabled": true,
 <% if $taiga::front::config::login_form_type { -%>
-    "loginFormType": <%= $taiga::front::config::login_form_type.to_json %>,
+    "loginFormType": <%= $taiga::front::config::login_form_type.stdlib::to_json %>,
 <% } -%>
     "privacyPolicyUrl": null,
     "termsOfServiceUrl": null,
     "maxUploadFileSize": null,
     "contribPlugins": [],
-    "gravatar": <%= $taiga::front::gravatar.to_json %>
+    "gravatar": <%= $taiga::front::gravatar.stdlib::to_json %>
 }


### PR DESCRIPTION
A bunch of stdlib functions have been namespaced in stdlib-9.0.0, and
the non-namespaced version now generate a warning.

Use the namespaced functions and bump stdlib dependency accordingly.
