### PR TITLE
Fix another non-namespaced `to_python`

### DIFF
--- a/templates/vhost/passenger_wsgi.py.epp
+++ b/templates/vhost/passenger_wsgi.py.epp
@@ -1,5 +1,5 @@
 import sys, os
-INTERP = <%= "${taiga::vhost::venv_directory}/bin/python".to_python %>
+INTERP = <%= "${taiga::vhost::venv_directory}/bin/python".stdlib::to_python %>
 #INTERP is present twice so that the new Python interpreter knows the actual executable path
 if sys.executable != INTERP: os.execl(INTERP, INTERP, *sys.argv)
 


### PR DESCRIPTION
The legacy function produce a warning.  Use the namespaced version
instead.
