### PR TITLE
Fix deployment with PostgreSQL 15

### DIFF
--- a/manifests/back/database.pp
+++ b/manifests/back/database.pp
@@ -8,6 +8,7 @@ class taiga::back::database {
 
   postgresql::server::db { $taiga::back::db_name:
     user     => $taiga::back::db_user,
+    owner    => $taiga::back::db_user,
     password => postgresql::postgresql_password($taiga::back::db_user, $taiga::back::db_password),
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {


### PR DESCRIPTION
We previously did not change the database owner for PostgreSQL,
resulting in the database being owned by the `postgres` user.

PostgreSQL 15 revoked the CREATE permission from all users except a
database owner from the public schema.  As a consequence, migration that
are expected to create objects are not allowed to do so with this
version and newer of PostgreSQL.

Explicitly make the database user the owner of it, to allow migrations.

Also include:
* #73
