### PR TITLE
Relocate Taiga repositories

### DIFF
--- a/manifests/back/repo.pp
+++ b/manifests/back/repo.pp
@@ -12,7 +12,7 @@ class taiga::back::repo {
   -> vcsrepo { $taiga::back::install_dir:
     ensure   => $taiga::back::repo_ensure,
     provider => 'git',
-    source   => 'https://github.com/kaleidos-ventures/taiga-back.git',
+    source   => 'https://github.com/taigaio/taiga-back.git',
     revision => $taiga::back::repo_revision,
     user     => $taiga::back::user,
   }

--- a/manifests/front/repo.pp
+++ b/manifests/front/repo.pp
@@ -12,7 +12,7 @@ class taiga::front::repo {
   -> vcsrepo { $taiga::front::install_dir:
     ensure   => $taiga::front::repo_ensure,
     provider => 'git',
-    source   => 'https://github.com/kaleidos-ventures/taiga-front-dist.git',
+    source   => 'https://github.com/taigaio/taiga-front-dist.git',
     revision => $taiga::front::repo_revision,
     user     => $taiga::front::user,
   }


### PR DESCRIPTION
Upstream has switched back to the original repos as (git) upstream.  Switch back to them as the next version is a major one.

This reverts commit 6928dcd811bc44a97280fd46342e2683c0608967.
